### PR TITLE
Add dependency on Alien::PCRE2 (awaiting next SWIG4 release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,10 @@ jobs:
         run: |
           cpanm --notest --installdeps .
 
+      - name: Install Alien::PCRE2 for share install
+        run: |
+          cpanm --notest Alien::PCRE2
+        if: matrix.alien-install-type == 'share'
       - name: Set ALIEN_INSTALL_TYPE
         shell: bash
         run: |
@@ -165,6 +169,9 @@ jobs:
       - name: Install Perl deps
         run: |
           cpanm --notest --installdeps .
+      - name: Install Alien::PCRE2 for share install
+        run: |
+          cpanm --notest Alien::PCRE2
       - name: Run tests
         run: |
           cpanm --verbose --test-only .

--- a/alienfile
+++ b/alienfile
@@ -7,9 +7,11 @@ plugin 'Probe::CommandLine' => (
   version => qr/SWIG Version (4\.[0-9\.]+)/,
 );
 
-share {
-  requires 'File::Which';
+plugin 'Build::SearchDep' => (
+  aliens => [qw( Alien::PCRE2 )],
+);
 
+share {
   start_url 'https://swig.org/download.html';
 
   plugin Download => (
@@ -19,17 +21,11 @@ share {
 
   plugin Extract => 'tar.gz';
 
-  my $has_pcre2 = 0;
-
-  if( File::Which::which('pcre2-config') ) {
-    $has_pcre2 = 1;
-  }
-
   plugin 'Build::Autoconf';
   build [
     join(' ',
       '%{configure}',
-      ( ! $has_pcre2 ? ( '--without-pcre' ) : () ),
+        '--with-pcre',
     ),
     '%{make}',
     '%{make} install',

--- a/alienfile
+++ b/alienfile
@@ -1,5 +1,7 @@
 use alienfile;
 
+use Env qw(@PATH);
+
 plugin 'Probe::CommandLine' => (
   command => 'swig',
   args    => [ '-version' ],
@@ -12,6 +14,7 @@ plugin 'Build::SearchDep' => (
 );
 
 share {
+  requires 'Alien::PCRE2';
   start_url 'https://swig.org/download.html';
 
   plugin Download => (
@@ -20,6 +23,16 @@ share {
   );
 
   plugin Extract => 'tar.gz';
+
+  meta->around_hook( prefer => sub {
+    my($orig, $build) = @_;
+
+    # path for pcre2-config
+    push @PATH, Alien::PCRE2->bin_dir;
+
+    $orig->($build);
+
+  });
 
   plugin 'Build::Autoconf';
   build [


### PR DESCRIPTION
The next release of SWIG (tentatively 4.1.0) after the current SWIG 4.0.2 will
drop support for PCRE (v1) API and switch to PCRE2.
